### PR TITLE
Ajout affichage de l'id dans recherche question

### DIFF
--- a/SRYEM/utils/specs_f/rechercherQuestions.js
+++ b/SRYEM/utils/specs_f/rechercherQuestions.js
@@ -15,7 +15,7 @@ function rechercherQuestions(motCle, questionBank) {
 
     // Parcourt chaque question trouvée et l'affiche avec son index (numérotation humaine).
     resultats.forEach((q, index) =>
-      console.log(`${index + 1}. [${q.type}] ${q.text}`)
+      console.log(`${index + 1}. [${q.type}] ${q.text} ; id : ${q.id}`)
     );
   }
 


### PR DESCRIPTION
L'id est désormais affiché lorsque l'utilisateur recherche des questions avec un mot clé.